### PR TITLE
Add support for image endpoints

### DIFF
--- a/src/the_cat_api/api.py
+++ b/src/the_cat_api/api.py
@@ -6,8 +6,31 @@ class TheCatAPI(Client):
     def __init__(self, key: str, version: int = 1):
         super().__init__(key, version)
 
-    async def search_images(self):
+    async def search_images(
+        self,
+        size: str = 'med',
+        mime_types: str = 'jpg',
+        format: str = 'json',
+        has_breeds: bool = True,
+        order: str = 'RANDOM',
+        page: int = 0,
+        limit: int = 1,
+        include_breeds: int = 1,
+        include_categories: int = 1
+    ):
         """
-        Search all approved images.
+        Search all approved images. 
         """
-        return await self.get('/images/search')
+        parameters = {
+            'size': size,
+            'mime_types': mime_types,
+            'format': format,
+            'has_breeds': str(has_breeds).lower(),
+            'order': order,
+            'page': page,
+            'limit': limit,
+            'include_breeds': include_breeds,
+            'include_categories': include_categories
+        }
+        # TODO: Handle format=src response
+        return await self.get('/images/search', parameters=parameters)

--- a/src/the_cat_api/api.py
+++ b/src/the_cat_api/api.py
@@ -45,3 +45,14 @@ class TheCatAPI(Client):
                 'sub_id': sub_id
             }
         return await self.get(f'/images/{image_id}', parameters=parameters)
+
+    async def get_analysis(self, image_id, sub_id=None):
+        """
+        Get the raw analysis results for any uploaded image.
+        """
+        parameters = {}
+        if sub_id is not None:
+            parameters = {
+                'sub_id': sub_id
+            }
+        return await self.get(f'/images/{image_id}/analysis', parameters=parameters)

--- a/src/the_cat_api/api.py
+++ b/src/the_cat_api/api.py
@@ -101,3 +101,12 @@ class TheCatAPI(Client):
             'breeds_id': breeds_id
         })
         return await self.post('/images/upload', data=data)
+
+    async def remove_image(
+        self,
+        image_id
+    ):
+        """
+        Delete an uploaded image.
+        """
+        await self.delete(f'/images/{image_id}')

--- a/src/the_cat_api/api.py
+++ b/src/the_cat_api/api.py
@@ -110,3 +110,26 @@ class TheCatAPI(Client):
         Delete an uploaded image.
         """
         await self.delete(f'/images/{image_id}')
+
+    async def uploaded_breeds(
+        self,
+        image_id
+    ):
+        return await self.get(f'/images/{image_id}/breeds')
+
+    async def upload_breed(
+        self,
+        image_id,
+        breed_id: int
+    ):
+        body = {
+            'breed_id': breed_id
+        }
+        return await self.post(f'/images/{image_id}/breeds', json=body)
+
+    async def delete_breed(
+        self,
+        image_id,
+        breed_id: int
+    ):
+        return await self.delete(f'/images/{image_id}/breeds/{breed_id}')

--- a/src/the_cat_api/api.py
+++ b/src/the_cat_api/api.py
@@ -34,3 +34,14 @@ class TheCatAPI(Client):
         }
         # TODO: Handle format=src response
         return await self.get('/images/search', parameters=parameters)
+
+    async def get_image(self, image_id, sub_id=None):
+        """
+        Return the image matching the ID.
+        """
+        parameters = {}
+        if sub_id is not None:
+            parameters = {
+                'sub_id': sub_id
+            }
+        return await self.get(f'/images/{image_id}', parameters=parameters)

--- a/src/the_cat_api/api.py
+++ b/src/the_cat_api/api.py
@@ -9,15 +9,15 @@ class TheCatAPI:
 
     async def search_images(
         self,
-        size: str = 'med',
-        mime_types: str = 'jpg',
-        format: str = 'json',
-        has_breeds: bool = True,
-        order: str = 'RANDOM',
-        page: int = 0,
-        limit: int = 1,
-        include_breeds: int = 1,
-        include_categories: int = 1
+        size = None,
+        mime_types = None,
+        format = None,
+        has_breeds = None,
+        order = None,
+        page = None,
+        limit = None,
+        include_breeds = None,
+        include_categories = None
     ):
         """
         Search all approved images. 
@@ -60,15 +60,15 @@ class TheCatAPI:
 
     async def uploaded_images(
         self,
-        limit: int = None,
-        page: int = None,
-        order: str = None,
-        sub_id: str = None,
-        breed_ids: str = None,
-        category_ids: str = None,
-        format: str = None,
-        original_filename: str = None,
-        user_id: str = None
+        limit = None,
+        page = None,
+        order = None,
+        sub_id = None,
+        breed_ids = None,
+        category_ids = None,
+        format = None,
+        original_filename = None,
+        user_id = None
     ):
         """
         Return your own uploaded images.
@@ -89,8 +89,8 @@ class TheCatAPI:
     async def upload_image(
         self,
         file,
-        sub_id: str = None,
-        breeds_id: str = None
+        sub_id = None,
+        breeds_id = None
     ):
         """
         Upload an image.
@@ -120,7 +120,7 @@ class TheCatAPI:
     async def upload_breed(
         self,
         image_id,
-        breed_id: int
+        breed_id
     ):
         body = {
             'breed_id': breed_id
@@ -130,6 +130,6 @@ class TheCatAPI:
     async def delete_breed(
         self,
         image_id,
-        breed_id: int
+        breed_id
     ):
         return await self.client.delete(f'/images/{image_id}/breeds/{breed_id}')

--- a/src/the_cat_api/api.py
+++ b/src/the_cat_api/api.py
@@ -85,3 +85,19 @@ class TheCatAPI(Client):
             'user_id': user_id
         })
         return await self.get(f'/images', parameters=parameters)
+
+    async def upload_image(
+        self,
+        file,
+        sub_id: str = None,
+        breeds_id: str = None
+    ):
+        """
+        Upload an image.
+        """
+        data = utils.remove_nones({
+            'file': open(file, 'rb'),
+            'sub_id': sub_id,
+            'breeds_id': breeds_id
+        })
+        return await self.post('/images/upload', data=data)

--- a/src/the_cat_api/api.py
+++ b/src/the_cat_api/api.py
@@ -2,10 +2,10 @@ from . import utils
 from .client import Client
 
 
-class TheCatAPI(Client):
+class TheCatAPI:
 
-    def __init__(self, key: str, version: int = 1):
-        super().__init__(key, version)
+    def __init__(self, key: str):
+        self.client = Client(key)
 
     async def search_images(
         self,
@@ -34,7 +34,7 @@ class TheCatAPI(Client):
             'include_categories': include_categories
         }
         # TODO: Handle format=src response
-        return await self.get('/images/search', parameters=parameters)
+        return await self.client.get('/images/search', parameters=parameters)
 
     async def get_image(self, image_id, sub_id=None):
         """
@@ -45,7 +45,7 @@ class TheCatAPI(Client):
             parameters = {
                 'sub_id': sub_id
             }
-        return await self.get(f'/images/{image_id}', parameters=parameters)
+        return await self.client.get(f'/images/{image_id}', parameters=parameters)
 
     async def get_analysis(self, image_id, sub_id=None):
         """
@@ -56,7 +56,7 @@ class TheCatAPI(Client):
             parameters = {
                 'sub_id': sub_id
             }
-        return await self.get(f'/images/{image_id}/analysis', parameters=parameters)
+        return await self.client.get(f'/images/{image_id}/analysis', parameters=parameters)
 
     async def uploaded_images(
         self,
@@ -84,7 +84,7 @@ class TheCatAPI(Client):
             'original_filename': original_filename,
             'user_id': user_id
         })
-        return await self.get(f'/images', parameters=parameters)
+        return await self.client.get(f'/images', parameters=parameters)
 
     async def upload_image(
         self,
@@ -100,7 +100,7 @@ class TheCatAPI(Client):
             'sub_id': sub_id,
             'breeds_id': breeds_id
         })
-        return await self.post('/images/upload', data=data)
+        return await self.client.post('/images/upload', data=data)
 
     async def remove_image(
         self,
@@ -109,7 +109,7 @@ class TheCatAPI(Client):
         """
         Delete an uploaded image.
         """
-        await self.delete(f'/images/{image_id}')
+        await self.client.delete(f'/images/{image_id}')
 
     async def uploaded_breeds(
         self,
@@ -125,11 +125,11 @@ class TheCatAPI(Client):
         body = {
             'breed_id': breed_id
         }
-        return await self.post(f'/images/{image_id}/breeds', json=body)
+        return await self.client.post(f'/images/{image_id}/breeds', json=body)
 
     async def delete_breed(
         self,
         image_id,
         breed_id: int
     ):
-        return await self.delete(f'/images/{image_id}/breeds/{breed_id}')
+        return await self.client.delete(f'/images/{image_id}/breeds/{breed_id}')

--- a/src/the_cat_api/api.py
+++ b/src/the_cat_api/api.py
@@ -1,3 +1,4 @@
+from . import utils
 from .client import Client
 
 
@@ -56,3 +57,31 @@ class TheCatAPI(Client):
                 'sub_id': sub_id
             }
         return await self.get(f'/images/{image_id}/analysis', parameters=parameters)
+
+    async def uploaded_images(
+        self,
+        limit: int = None,
+        page: int = None,
+        order: str = None,
+        sub_id: str = None,
+        breed_ids: str = None,
+        category_ids: str = None,
+        format: str = None,
+        original_filename: str = None,
+        user_id: str = None
+    ):
+        """
+        Return your own uploaded images.
+        """
+        parameters = utils.remove_nones({
+            'limit': limit,
+            'page': page,
+            'order': order,
+            'sub_id': sub_id,
+            'breed_ids': breed_ids,
+            'category_ids': category_ids,
+            'format': format,
+            'original_filename': original_filename,
+            'user_id': user_id
+        })
+        return await self.get(f'/images', parameters=parameters)

--- a/src/the_cat_api/client.py
+++ b/src/the_cat_api/client.py
@@ -42,12 +42,12 @@ class Client:
     async def close(self):
         await self.session.close()
 
-    async def request(self, method, endpoint, parameters=None, data=None):
+    async def request(self, method, endpoint, parameters=None, data=None, json=None):
         headers = {
             'x-api-key': self.key
         }
         version = f'/v{self.version}'
-        async with self.session.request(method, self.host + version + endpoint, params=parameters, headers=headers, data=data) as response:
+        async with self.session.request(method, self.host + version + endpoint, params=parameters, headers=headers, data=data, json=json) as response:
             await check_status(response)
             try:
                 content = await response.json()

--- a/src/the_cat_api/client.py
+++ b/src/the_cat_api/client.py
@@ -49,11 +49,17 @@ class Client:
         version = f'/v{self.version}'
         async with self.session.request(method, self.host + version + endpoint, params=parameters, headers=headers, data=data) as response:
             await check_status(response)
-            content = await response.json()
-        return content
+            try:
+                content = await response.json()
+                return content
+            except ContentTypeError:
+                pass
 
     async def get(self, endpoint, **kwargs):
         return await self.request('GET', endpoint, **kwargs)
 
     async def post(self, endpoint, **kwargs):
         return await self.request('POST', endpoint, **kwargs)
+
+    async def delete(self, endpoint):
+        return await self.request('DELETE', endpoint)

--- a/src/the_cat_api/client.py
+++ b/src/the_cat_api/client.py
@@ -33,21 +33,37 @@ async def check_status(response: ClientResponse):
 
 class Client:
 
-    def __init__(self, key: str, version: int):
+    def __init__(
+        self,
+        key: str,
+        *,
+        host = 'https://api.thecatapi.com',
+        version = 1
+    ):
         self.key = key
+        self.host = host
         self.version = version
-        self.host = 'https://api.thecatapi.com'
         self.session = ClientSession()
 
     async def close(self):
         await self.session.close()
 
-    async def request(self, method, endpoint, parameters=None, data=None, json=None):
+    async def request(
+        self,
+        method,
+        url,
+        parameters = None,
+        data = None,
+        json = None
+    ) -> ClientResponse:
         headers = {
             'x-api-key': self.key
         }
-        version = f'/v{self.version}'
-        async with self.session.request(method, self.host + version + endpoint, params=parameters, headers=headers, data=data, json=json) as response:
+        url = f'{self.host}/v{self.version}/{url}'
+        async with self.session.request(
+            method, url, params=parameters, headers=headers, data=data,
+            json=json
+        ) as response:
             await check_status(response)
             try:
                 content = await response.json()
@@ -55,11 +71,11 @@ class Client:
             except ContentTypeError:
                 pass
 
-    async def get(self, endpoint, **kwargs):
-        return await self.request('GET', endpoint, **kwargs)
+    async def get(self, url, **kwargs):
+        return await self.request('GET', url, **kwargs)
 
-    async def post(self, endpoint, **kwargs):
-        return await self.request('POST', endpoint, **kwargs)
+    async def post(self, url, **kwargs):
+        return await self.request('POST', url, **kwargs)
 
-    async def delete(self, endpoint):
-        return await self.request('DELETE', endpoint)
+    async def delete(self, url):
+        return await self.request('DELETE', url)

--- a/src/the_cat_api/client.py
+++ b/src/the_cat_api/client.py
@@ -1,4 +1,5 @@
 from aiohttp import (
+    ContentTypeError,
     ClientResponse,
     ClientSession
 )
@@ -12,7 +13,10 @@ from .exceptions import (
 async def get_contents(response: ClientResponse):
     status_code = response.status
     reason = response.reason
-    body = await response.json()
+    try:
+        body = await response.json()
+    except ContentTypeError:
+        body = await response.text()
     return status_code, reason, body
 
 
@@ -38,15 +42,18 @@ class Client:
     async def close(self):
         await self.session.close()
 
-    async def request(self, method, endpoint, parameters=None):
+    async def request(self, method, endpoint, parameters=None, data=None):
         headers = {
             'x-api-key': self.key
         }
         version = f'/v{self.version}'
-        async with self.session.request(method, self.host + version + endpoint, params=parameters, headers=headers) as response:
+        async with self.session.request(method, self.host + version + endpoint, params=parameters, headers=headers, data=data) as response:
             await check_status(response)
             content = await response.json()
         return content
 
     async def get(self, endpoint, **kwargs):
         return await self.request('GET', endpoint, **kwargs)
+
+    async def post(self, endpoint, **kwargs):
+        return await self.request('POST', endpoint, **kwargs)

--- a/src/the_cat_api/utils.py
+++ b/src/the_cat_api/utils.py
@@ -1,0 +1,9 @@
+def remove_nones(dict_: dict) -> dict:
+    """
+    Returns the dictionary but without keys whose value is `None`.
+    """
+    result = {}
+    for key, value in dict_.items():
+        if value is not None:
+            result[key] = value
+    return result


### PR DESCRIPTION
Adds methods for sending requests to all `images` endpoints. Added utility to remove parameters (or any data contained in a dictionary) if their values are set to `None`. This is useful for reducing the amount of data needed to be sent to the server if the client is happy with the default behaviour. Changed `Client` to be used as an internal object rather than via inheritance.